### PR TITLE
Better error processing

### DIFF
--- a/alysis/_rpc.py
+++ b/alysis/_rpc.py
@@ -5,7 +5,13 @@ from typing import cast
 
 from compages import StructuringError, UnstructuringError
 
-from ._exceptions import BlockNotFound, TransactionFailed, TransactionNotFound, TransactionReverted
+from ._exceptions import (
+    BlockNotFound,
+    TransactionFailed,
+    TransactionNotFound,
+    TransactionReverted,
+    ValidationError,
+)
 from ._node import Node
 from ._schema import (
     JSON,
@@ -102,7 +108,7 @@ class RPCNode:
         try:
             return self._methods[method_name](params)
 
-        except StructuringError as exc:
+        except (StructuringError, ValidationError) as exc:
             raise RPCError(RPCErrorCode.INVALID_PARAMETER, str(exc)) from exc
 
         except UnstructuringError as exc:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,9 +8,18 @@ Changed
 ^^^^^^^
 
 - ``Node.take_snapshot()`` removed, instead ``Node`` objects are now deep-copyable. (PR_18_)
+- ``RPCErrorCode.INVALID_REQEST`` removed. (PR_20_)
+- Transaction validation errors now raise ``ValidationError`` instead of ``TransactionFailed``. (PR_20_)
+
+
+Fixed
+^^^^^
+
+- Process transaction validation errors and missing method errors correctly on RPC level. (PR_20_)
 
 
 .. _PR_18: https://github.com/fjarri/compages/pull/18
+.. _PR_20: https://github.com/fjarri/compages/pull/20
 
 
 0.2.0 (2024-03-05)


### PR DESCRIPTION
- Removed `RPCErrorCode.INVALID_REQUEST` - we don't process raw RPC requests, so it is not used
- Use `RPCErrorCode.METHOD_NOT_FOUND` if the method was not found. Fixes #6 
- Raise `ValidationError` appropriately when transaction validation fails. Fixes #11, fixes #14
- Convert `ValidationError` into `RPCErrorCode.INVALID_REQUEST` on RPC level. 